### PR TITLE
Test for YamlMapping.literalBlockScalar

### DIFF
--- a/src/test/java/com/amihaiemil/eoyaml/RtYamlInputTest.java
+++ b/src/test/java/com/amihaiemil/eoyaml/RtYamlInputTest.java
@@ -35,7 +35,6 @@ import java.util.Set;
 import org.apache.commons.io.IOUtils;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
-import org.junit.Ignore;
 import org.junit.Test;
 
 /**

--- a/src/test/java/com/amihaiemil/eoyaml/YamlIndentationTestCase.java
+++ b/src/test/java/com/amihaiemil/eoyaml/YamlIndentationTestCase.java
@@ -33,6 +33,9 @@ import org.hamcrest.Matchers;
 import org.junit.Test;
 
 import java.io.File;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
 
 /**
  * Test cases regarding an input YAML's indentation, particularly
@@ -144,4 +147,32 @@ public final class YamlIndentationTestCase {
             Matchers.equalTo("rultor")
         );
     }
+
+    /**
+     * A badly indented YAML sequence throws an exception.
+     * @throws Exception If something goes wrong.
+     */
+    @Test
+    public void testIndentationAndYamlIndentationException() throws Exception {
+        try {
+            final List<YamlLine> lines = new ArrayList<>();
+            lines.add(new RtYamlLine("value1", 1));
+            lines.add(new RtYamlLine(" lGvSz", 2));
+            lines.add(new RtYamlLine("value3", 3));
+            final YamlLines yamlLines = new AllYamlLines(lines);
+            final YamlNode seq = yamlLines.toYamlNode(
+                    new RtYamlLine("foldedSequence:|-", 0), false);
+            final Collection<YamlNode> values = ((YamlSequence) seq).values();
+            MatcherAssert.assertThat(
+                    "testIndentationAndYamlIndentationException "
+                    + "should have thrown YamlIndentationException",
+                    false);
+        } catch (final YamlIndentationException expected) {
+            MatcherAssert.assertThat(expected.getMessage(), Matchers.equalTo(
+                    "Indentation of line 3 [lGvSz] is greater "
+                    + "than the one of line 2 [value1]. "
+                    + "It should be less or equal."));
+        }
+    }
+
 }

--- a/src/test/java/com/amihaiemil/eoyaml/YamlIndentationTestCase.java
+++ b/src/test/java/com/amihaiemil/eoyaml/YamlIndentationTestCase.java
@@ -30,6 +30,7 @@ package com.amihaiemil.eoyaml;
 import com.amihaiemil.eoyaml.exceptions.YamlIndentationException;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.File;
@@ -153,7 +154,7 @@ public final class YamlIndentationTestCase {
      * @throws Exception If something goes wrong.
      */
     @Test
-    public void testIndentationAndYamlIndentationException() throws Exception {
+    public void badlyIndentedSequenceThrowsException() throws Exception {
         try {
             final List<YamlLine> lines = new ArrayList<>();
             lines.add(new RtYamlLine("value1", 1));
@@ -163,10 +164,8 @@ public final class YamlIndentationTestCase {
             final YamlNode seq = yamlLines.toYamlNode(
                     new RtYamlLine("foldedSequence:|-", 0), false);
             final Collection<YamlNode> values = ((YamlSequence) seq).values();
-            MatcherAssert.assertThat(
-                    "testIndentationAndYamlIndentationException "
-                    + "should have thrown YamlIndentationException",
-                    false);
+            Assert.fail("badlyIntendedSequenceThrowsException "
+                    + "should have thrown YamlIndentationException");
         } catch (final YamlIndentationException expected) {
             MatcherAssert.assertThat(expected.getMessage(), Matchers.equalTo(
                     "Indentation of line 3 [lGvSz] is greater "


### PR DESCRIPTION
Test that emptyMapping.literalBlockScalar("y:v}SV5HR!Y({UBa;x4G") is null when literalBlockScalar(...) is called with the parameter key = "y:v}SV5HR!Y({UBa;x4G".
This tests the method [YamlMapping.literalBlockScalar](https://github.com/lacinoire/eo-yaml/blob/a5369f2fdf0c4d0fb55f1c45cc898eeaa1d8b25b/src/main/java/com/amihaiemil/eoyaml/YamlMapping.java#L204).
The test is based on [returnsCommentFromDecoratedObject](https://github.com/lacinoire/eo-yaml/blob/a5369f2fdf0c4d0fb55f1c45cc898eeaa1d8b25b/src/test/java/com/amihaiemil/eoyaml/EmptyYamlMappingTest.java#L60).

-----
We're opening these pull requests as part of a research study on automatically generating test cases and descriptions for developers. Every PR is manually reviewed and created, we only propose tests that we believe are useful for a project.
If you want to help us improve our approach you can give us more detailed feedback: [Link to survey](...).
To learn more about our approach and study, check out our [website](...).
If are interested in receiving more of PRs like this one click [here](...).
If this project should not receive any more PRs like this, you can comment "not interested" and close the request.
